### PR TITLE
Alternate table row colors; responsive CSS

### DIFF
--- a/globi.css
+++ b/globi.css
@@ -54,3 +54,75 @@ body {
 .menu li:last-child a { border-right: none; }
  
 .menu li:hover > a { color: rgba(0,0,255,.9); }
+
+thead {
+  border-bottom: 1px solid #000;
+}
+
+tr.interaction:nth-child(even) {
+  background: #ccc;
+}
+
+tr.interaction td {
+  border: none;
+}
+
+tr.interaction td li {
+  list-style-type: none;
+  margin-bottom: 8px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-all;
+  word-break: break-word;
+}
+
+@media (max-width: 767px) {
+  .menu li:first-child {
+    float: none;
+  }
+  
+  .ui-widget {
+    clear: both;
+  }
+
+  table, tr {
+    display: block;
+    max-width: 100%;
+  }
+  
+  td {
+    display: block;
+  }
+  
+  thead {
+    display: none;
+  }
+  
+  tr.interaction td table {
+    display: block;
+  }
+  
+  tr.interaction td table, tr.interaction td li {
+    clear: both;
+    margin-top: 10px;
+  }
+  
+  tr.interaction td table tbody, tr.interaction td table tr, tr.interaction td table td {
+    display: block;
+    float: left;
+  }
+  
+  tr.interaction > td {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  
+  tr.interaction > td:nth-child(2) {
+    font-size: 120%;
+    display: block;
+    clear: both;
+    padding: 10px;
+    text-align: center;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -89,10 +89,20 @@ $(function () {
 
         var callback = function (interactions) {
             var resultDiv = document.getElementById('result');
-            $('.interaction').remove();
+            $('.interaction, thead').remove();
             var distinctNames = {};
             var distinctInteractions = {};
             var counter = 0;
+            
+            var header = document.createElement('thead');
+            var columns = ['Organism 1', 'Interaction', 'Organism 2', 'Sources'];
+            for (var c = 0; c < columns.length; c++) {
+              var th = document.createElement('th');
+              th.innerHTML = columns[c];
+              header.appendChild(th);
+            }
+            resultDiv.appendChild(header);
+            
             interactions.forEach(function (interaction) {
                 if (distinctNames[interaction.target_taxon_name] !== interaction.target_taxon_name) {
                     row = document.createElement('tr');


### PR DESCRIPTION
I'm up for talking about design ideas, but two things which I've written here to improve usability for me are:

1) adding headers and alternating table row colors, so it's easier to see the list of interactions

![screen shot 2015-10-23 at 1 04 02 pm](https://cloud.githubusercontent.com/assets/643918/10703715/cbddba5a-7986-11e5-89b2-44201e345c3c.png)

2) making the site mobile-friendly

by letting URLs go onto multiple lines, and splitting up table rows on smaller devices, it's possible to see the list of interactions

![screen shot 2015-10-23 at 1 05 00 pm](https://cloud.githubusercontent.com/assets/643918/10703739/ebd092c4-7986-11e5-86cb-f0d48ca64bef.png)

The third thing that I was looking at was pagination... would you use a tool like jQuery DataTables, or would you change it to server-side pages?  I think the main issue with server-side is you wouldn't be able to Ctrl+F for other information in the list